### PR TITLE
Fix README Winter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ refresh automatically.
 [![Go Reference](https://pkg.go.dev/badge/twos.dev/winter.svg)](https://pkg.go.dev/twos.dev/winter)
 
 Winter is the bespoke static website generator that powers twos.dev. It can be
-used to power your static website as well, as a CLI or Go library. See
-[`winter/README.md`](./winter) for details.
+used to power your static website as well, as a CLI or Go library. See the
+[winter README](https://github.com/glacials/winter) for details.


### PR DESCRIPTION
## Summary
- fix broken Winter README link

## Testing
- `npm install`
- `npx prettier -w README.md`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a51376cf48332b8269a3578a11944