### PR TITLE
Add draft post: When to Caption Your Photos

### DIFF
--- a/src/warm/when-to-caption-your-photos.md
+++ b/src/warm/when-to-caption-your-photos.md
@@ -1,0 +1,119 @@
+---
+date: 2026-07-04
+filename: when-to-caption-your-photos.html
+preview: A small rule for when captions help photos, and when they make them worse.
+type: post
+---
+
+# When to Caption Your Photos
+
+I don’t usually caption my photos.
+
+That’s not because I think captions are bad, exactly. I think they’re easy to use badly.
+
+A good photo should do something on its own. It should pull your attention somewhere, or make you feel a little stuck on it, or give you enough to chew on without me standing next to you saying, “Notice the loneliness of the empty chair,” or “This one is about the passage of time.”
+
+I do not want to tell you what to see in my photos. I want you to look at them.
+
+That sounds precious, but I think it’s a real distinction. A caption can be a useful handle, but it can also be a little interpretive prison. Once I tell you what the photo is “about,” I’ve made the photo smaller. I’ve collapsed some of its possible readings into mine.
+
+This is especially true for the kind of photography I like making. Travel photos, street photos, texture photos, weird little arrangement-of-the-world photos. The whole appeal is often that I noticed something I don’t fully understand. A chair in the wrong place. A sign with too many fonts. A person’s posture. A wall that has collected ten years of small decisions.
+
+Writing “loneliness in Copenhagen” underneath that is not adding information. It’s putting a bumper sticker on it.
+
+## Captions vs. context
+
+There is a version of this opinion that goes too far:
+
+> Photos should speak for themselves.
+
+This is mostly true, but mostly true is where a lot of bad rules live.
+
+Photos do not actually speak for themselves. Or at least, they don’t speak equally to everyone. A photo may contain a sign in another language. It may show a local custom. It may depend on a joke, a historical moment, a place name, or a relationship between people that is obvious to me and invisible to everyone else.
+
+So I think the better distinction is not caption vs. no caption.
+
+It’s interpretation vs. context.
+
+Bad, for my purposes:
+
+> A lonely man waits for the city to forget him.
+
+Better:
+
+> Bus stop outside Nørreport Station.
+
+Also fine:
+
+> Sign reads: “Please do not feed the birds.”
+
+The first caption tells you what emotion to have. The second tells you where we are. The third unlocks a piece of the image you could not read on your own.
+
+These are different tools that unfortunately share a name.
+
+## The translation exception
+
+The place I most often want a caption is when the photo includes text I couldn’t read at the time, or text most of my viewers probably can’t read.
+
+If I take a photo of a Danish sign, and the sign says something funny or bureaucratic or unexpectedly poetic, translating it in the caption feels fair. The sign is already part of the photo. I’m not adding meaning from the outside; I’m making the visible meaning available.
+
+Something like:
+
+> “No bicycles in the courtyard.”
+
+That does not tell you what the photo means. It tells you what one object in the photo says.
+
+This is probably less than 1% of my photos, but it’s a real 1%.
+
+## The archive exception
+
+There is another kind of caption that feels boring in the present and precious in the future.
+
+Names. Dates. Places. Occasions.
+
+I almost never want this under a photo in a public album, but I often want it attached somewhere. Ten years later, “Copenhagen, 2026” may matter more than I expect. “Taken outside the hotel after the rain stopped” may matter more than I expect. “This was the bakery the stranger recommended” may matter more than I expect.
+
+This is not really a captioning problem. It’s an archiving problem.
+
+Maybe the answer is not to put all of that under the photo. Maybe the answer is to keep it in filenames, albums, EXIF metadata, notes, voice memos, or a private journal.
+
+Public captions and private memory do not have to be the same system.
+
+## When I would caption
+
+My current rule is:
+
+> Caption a photo when the caption adds information the viewer could not reasonably get from the image.
+
+That includes:
+
+- translations
+- names of places when the place matters
+- names of people when identification matters
+- factual context for documentary photos
+- archival notes I know I will care about later
+
+It does not include:
+
+- telling the viewer what to feel
+- explaining why the photo is good
+- naming the theme
+- writing a tiny poem because I’m afraid the image is too quiet
+
+That last one is the trap for me. If I feel tempted to caption a photo because I’m worried people won’t “get it,” that may be a sign the photo does not work. Or it may be a sign that the photo works in a quieter way than I’m comfortable with.
+
+Either way, the caption is probably not the fix.
+
+## Letting the photo stay weird
+
+The best argument against my default is accessibility. Context can help people enter a photo. It can make the work less private. It can turn a vague image into a specific one, and specificity is often good.
+
+But the best argument for my default is that ambiguity is also a feature. Sometimes the part of a photo I like is exactly that I don’t know what to do with it. I don’t want to explain the photo because explanation is not the experience I’m trying to preserve.
+
+I want the viewer to have a little room.
+
+So I’ll keep mostly not captioning my photos. Not as a law, and not because captions are beneath the medium, but because most of the captions I’m tempted to write would make the photo worse.
+
+When a caption translates, identifies, or preserves, I’ll use one.
+
+When it explains, I’ll try not to.


### PR DESCRIPTION
Adds a warm draft for “When to Caption Your Photos.”

Notes:
- Added under `src/warm/` so it behaves like an in-progress draft post.
- Did not edit generated `dist/` output.
- Based on the draft text from the ChatGPT conversation on 2026-07-04.