### PR TITLE
Version site stylesheet

### DIFF
--- a/src/templates/_head.html.tmpl
+++ b/src/templates/_head.html.tmpl
@@ -110,7 +110,7 @@
     {{- end -}}
   {{- end -}}
 </title>
-<link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="/style.css?v=2" />
 
 <link
   rel="stylesheet"


### PR DESCRIPTION
## Summary

- add a version query to the shared `style.css` URL
- use an absolute stylesheet path consistently across generated pages

## Why

The live HTML is cached for 10 minutes, but `style.css` is cached for four hours. After the gallery update deployed, returning mobile users could receive the new pinch-zoom JavaScript alongside stale CSS that lacked the zoom transform. That created an invisible zoom state and prevented tap-to-close until the user pinched back to 1×.

## Impact

Browsers will request the matching stylesheet version instead of reusing the pre-gallery CSS, so mobile pinch zoom becomes visible immediately after deployment.

## Validation

- Prettier check passed for `src/templates/_head.html.tmpl`
- Winter build completed with 276 pages and 169 images
- generated `dist/photos.html` contains `/style.css?v=2`
- `git diff --check` passed