### PR TITLE
Keep gallery swipe peers visible

### DIFF
--- a/src/templates/_js.html.tmpl
+++ b/src/templates/_js.html.tmpl
@@ -1083,9 +1083,9 @@
       fullsize.loading = "eager";
     }
 
-    if (isGalleryFullsizeReady(item)) {
-      item.classList.add("is-loaded", "is-motion-fullsize");
-    }
+    // Keep the peer on its already-decoded thumbnail throughout the swipe.
+    // A preloaded full-size image can be complete but still waiting for its
+    // large bitmap to decode, which would otherwise leave a blank frame here.
 
     return item;
   }


### PR DESCRIPTION
## Summary

- keep the incoming gallery peer on its decoded thumbnail for the complete swipe animation
- promote the preloaded full-size bitmap only after navigation settles

## Why

Preloading made adjacent full-size images report `complete` before their large bitmaps were necessarily decoded. The swipe path treated that network-complete state as paint-ready, hid the thumbnail, and exposed a temporarily blank full-size layer. The incoming photo therefore appeared to pop in partway through the animation.

## Impact

The adjacent photo remains visibly attached to the user's finger throughout the swipe, while full-size preloading still happens in the background.

## Validation

- Prettier check passed for `src/templates/_js.html.tmpl`
- Winter build completed with 276 pages and 169 images
- `git diff --check` passed
- mobile Chromium test delayed the incoming full-size request by two seconds and confirmed at the swipe midpoint that the peer thumbnail was displayed and visible, the full-size layer remained hidden, and the thumbnail was positioned inside the entering viewport